### PR TITLE
Update libsodium to 1.0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *xcuserdata*
 libsodium/*
 libsodium_dist
+
+LibSodiumTester/.DS_Store

--- a/LibSodiumTester/LibSodiumTester.xcodeproj/project.pbxproj
+++ b/LibSodiumTester/LibSodiumTester.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -256,11 +256,11 @@
 		3AAEA0F618B05CB500A5E10C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = DrewCrawfordApps;
 			};
 			buildConfigurationList = 3AAEA0F918B05CB500A5E10C /* Build configuration list for PBXProject "LibSodiumTester" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 11.4";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -323,17 +323,32 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -351,7 +366,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../libsodium_dist/include,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -365,17 +380,31 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -387,7 +416,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					../libsodium_dist/include,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -396,10 +425,13 @@
 		3AAEA12518B05CB600A5E10C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				DEVELOPMENT_TEAM = Z9T56A6LQ6;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(PROJECT_DIR)/../libsodium_dist/**",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "LibSodiumTester/LibSodiumTester-Prefix.pch";
@@ -410,8 +442,9 @@
 				INFOPLIST_FILE = "LibSodiumTesterTests/LibSodiumTesterTests-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Users/drew/Dropbox/Code/libzmq-ios/libsodium-ios/libsodium_dist/lib",
+					"$(PROJECT_DIR)/../libsodium_dist/**",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dca.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -420,6 +453,8 @@
 		3AAEA12618B05CB600A5E10C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				DEVELOPMENT_TEAM = Z9T56A6LQ6;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -430,8 +465,9 @@
 				INFOPLIST_FILE = "LibSodiumTesterTests/LibSodiumTesterTests-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Users/drew/Dropbox/Code/libzmq-ios/libsodium-ios/libsodium_dist/lib",
+					"$(PROJECT_DIR)/../libsodium_dist/**",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dca.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};

--- a/LibSodiumTester/LibSodiumTester.xcodeproj/project.pbxproj
+++ b/LibSodiumTester/LibSodiumTester.xcodeproj/project.pbxproj
@@ -261,10 +261,11 @@
 			};
 			buildConfigurationList = 3AAEA0F918B05CB500A5E10C /* Build configuration list for PBXProject "LibSodiumTester" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 3AAEA0F518B05CB500A5E10C;
 			productRefGroup = 3AAEA0FF18B05CB500A5E10C /* Products */;

--- a/LibSodiumTester/LibSodiumTester.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LibSodiumTester/LibSodiumTester.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/LibSodiumTester/LibSodiumTesterTests/LibSodiumTesterTests-Info.plist
+++ b/LibSodiumTester/LibSodiumTesterTests/LibSodiumTesterTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.dca.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/LibSodiumTester/LibSodiumTesterTests/LibSodiumTesterTests.m
+++ b/LibSodiumTester/LibSodiumTesterTests/LibSodiumTesterTests.m
@@ -3,11 +3,14 @@
 //  LibSodiumTesterTests
 //
 //  Created by Drew Crawford on 2/15/14.
+//  Modified by Joseph Zurowski on 10/11/20
 //  Copyright (c) 2014 DrewCrawfordApps. All rights reserved.
+//  Maintained 2020 Dunkel Web Services LLC. https://dws.llc/
 //
 
 #import <XCTest/XCTest.h>
 #import <sodium.h>
+#include <stdio.h>
 
 @interface LibSodiumTesterTests : XCTestCase
 
@@ -105,8 +108,6 @@
 }
 
 - (void) testBox2 {
-#include <stdio.h>
-    
     NSMutableString *compare1 = [[NSMutableString alloc ] init];
     unsigned char bobsk[32] = {
         0x5d,0xab,0x08,0x7e,0x62,0x4a,0x8a,0x4b

--- a/libsodium.sh
+++ b/libsodium.sh
@@ -10,7 +10,7 @@ rm libsodium-1.0.18.tar.gz
 mv libsodium-1.0.18 libsodium
 
 LIBNAME="libsodium.a"
-ARCHS=${ARCHS:-"armv7 armv7s arm64 i386 x86_64"}
+ARCHS=${ARCHS:-"armv7 armv7s arm64 x86_64"}
 DEVELOPER=$(xcode-select -print-path)
 LIPO=$(xcrun -sdk iphoneos -find lipo)
 #LIPO=lipo
@@ -69,14 +69,6 @@ do
 	    export LDFLAGS="-mthumb -arch ${ARCH} -isysroot ${ISDKROOT}"
             ;;
         arm64)
-	    PLATFORM="iPhoneOS"
-	    HOST="arm-apple-darwin"
-	    export BASEDIR="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
-	    export ISDKROOT="${BASEDIR}/SDKs/${PLATFORM}${SDK}.sdk"
-	    export CFLAGS="-arch ${ARCH} -isysroot ${ISDKROOT} ${OTHER_CFLAGS}"
-	    export LDFLAGS="-mthumb -arch ${ARCH} -isysroot ${ISDKROOT}"
-            ;;
-        i386)
 	    PLATFORM="iPhoneSimulator"
 	    HOST="${ARCH}-apple-darwin"
 	    export BASEDIR="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"

--- a/libsodium.sh
+++ b/libsodium.sh
@@ -74,7 +74,7 @@ do
 	    export BASEDIR="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
 	    export ISDKROOT="${BASEDIR}/SDKs/${PLATFORM}${SDK}.sdk"
 	    export CFLAGS="-arch ${ARCH} -isysroot ${ISDKROOT} -miphoneos-version-min=${SDK} ${OTHER_CFLAGS}"
-	    export LDFLAGS="-m32 -arch ${ARCH}"
+	    export LDFLAGS="-arch ${ARCH}"
             ;;
         x86_64)
 	    PLATFORM="iPhoneSimulator"

--- a/libsodium.sh
+++ b/libsodium.sh
@@ -4,10 +4,10 @@
 
 rm -rf libsodium
 set -e
-curl -O -L https://github.com/jedisct1/libsodium/releases/download/0.6.1/libsodium-0.6.1.tar.gz
-tar xzf libsodium-0.6.1.tar.gz
-rm libsodium-0.6.1.tar.gz
-mv libsodium-0.6.1 libsodium
+curl -O -L https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz
+tar xzf libsodium-1.0.18.tar.gz
+rm libsodium-1.0.18.tar.gz
+mv libsodium-1.0.18 libsodium
 
 LIBNAME="libsodium.a"
 ARCHS=${ARCHS:-"armv7 armv7s arm64 i386 x86_64"}


### PR DESCRIPTION
An update 7 years overdue! All test suites compile successfully and will run on Simulator and real hardware.

Some notes:
- i386 build target was dropped as it is no longer supported in Clang
- Minimum targetable iOS version is now 12.0 (from 7.0)
- Minimum supported XCode version is now 11.4 (from 3.2)
- Absolute paths were removed and are now relative to the XCode project path (will build anywhere now!)